### PR TITLE
feat: allow caller to set static ip address in a network

### DIFF
--- a/super_orchestrator/src/api_docker/container_network.rs
+++ b/super_orchestrator/src/api_docker/container_network.rs
@@ -1,5 +1,9 @@
 use std::{
-    collections::HashMap, net::IpAddr, path::PathBuf, str::FromStr, time::{Duration, Instant}
+    collections::HashMap,
+    net::IpAddr,
+    path::PathBuf,
+    str::FromStr,
+    time::{Duration, Instant},
 };
 
 // reexports from bollard. `IpamConfig` is reexported because it is part of `Ipam`
@@ -83,8 +87,8 @@ pub struct ExtraAddContainerOptions {
     /// If not set, will use the container's name.
     pub hostname: Option<String>,
     pub mac_address: Option<String>,
-    /// Caution, when setting ip addr manually, make sure your gateway can't assign other
-    /// containers to the same address.
+    /// Caution, when setting ip addr manually, make sure your gateway can't
+    /// assign other containers to the same address.
     pub ip_addr: Option<IpAddr>,
 }
 

--- a/super_orchestrator/src/api_docker/container_network.rs
+++ b/super_orchestrator/src/api_docker/container_network.rs
@@ -1,8 +1,5 @@
 use std::{
-    collections::HashMap,
-    path::PathBuf,
-    str::FromStr,
-    time::{Duration, Instant},
+    collections::HashMap, net::IpAddr, path::PathBuf, str::FromStr, time::{Duration, Instant}
 };
 
 // reexports from bollard. `IpamConfig` is reexported because it is part of `Ipam`
@@ -83,8 +80,12 @@ pub struct OutputDirConfig {
 /// Extra options related to `docker create`
 #[derive(Debug, Clone, Default)]
 pub struct ExtraAddContainerOptions {
+    /// If not set, will use the container's name.
     pub hostname: Option<String>,
     pub mac_address: Option<String>,
+    /// Caution, when setting ip addr manually, make sure your gateway can't assign other
+    /// containers to the same address.
+    pub ip_addr: Option<IpAddr>,
 }
 
 // TODO make the rest of `super_orchestrator` use tokio::signal::ctrl_c instead,

--- a/super_orchestrator/src/api_docker/container_runner.rs
+++ b/super_orchestrator/src/api_docker/container_runner.rs
@@ -372,7 +372,7 @@ pub async fn total_teardown(
     let mut errs = join_all(futs)
         .await
         .into_iter()
-        .filter_map(|res| if let Err(err) = res { Some(err) } else { None })
+        .filter_map(Result::err)
         .collect::<Vec<_>>();
 
     if let Err(err) = docker.remove_network(network_name).await.stack() {

--- a/super_orchestrator/src/api_docker/container_runner.rs
+++ b/super_orchestrator/src/api_docker/container_runner.rs
@@ -163,10 +163,13 @@ impl ContainerRunner {
                     networking_config: Some(bollard::container::NetworkingConfig {
                         endpoints_config: [(
                             network_name,
-                            self.network_opts.ip_addr.map(|ip_addr| EndpointSettings {
-                                ip_address: Some(ip_addr.to_string()),
-                                ..Default::default()
-                            }).unwrap_or_default(),
+                            self.network_opts
+                                .ip_addr
+                                .map(|ip_addr| EndpointSettings {
+                                    ip_address: Some(ip_addr.to_string()),
+                                    ..Default::default()
+                                })
+                                .unwrap_or_default(),
                         )]
                         .into_iter()
                         .collect(),

--- a/super_orchestrator/src/api_docker/container_runner.rs
+++ b/super_orchestrator/src/api_docker/container_runner.rs
@@ -7,6 +7,7 @@ use std::{
 
 // reexport from bollard
 pub use bollard::secret::DeviceMapping;
+use bollard::secret::EndpointSettings;
 use stacked_errors::{Result, StackableErr};
 use tokio::{io::AsyncWriteExt, sync::Mutex};
 
@@ -162,8 +163,10 @@ impl ContainerRunner {
                     networking_config: Some(bollard::container::NetworkingConfig {
                         endpoints_config: [(
                             network_name,
-                            // TODO: Could add some configuration for the network here
-                            Default::default(),
+                            self.network_opts.ip_addr.map(|ip_addr| EndpointSettings {
+                                ip_address: Some(ip_addr.to_string()),
+                                ..Default::default()
+                            }).unwrap_or_default(),
                         )]
                         .into_iter()
                         .collect(),

--- a/super_orchestrator/src/api_docker/container_runner.rs
+++ b/super_orchestrator/src/api_docker/container_runner.rs
@@ -8,6 +8,7 @@ use std::{
 // reexport from bollard
 pub use bollard::secret::DeviceMapping;
 use bollard::secret::EndpointSettings;
+use futures::future::join_all;
 use stacked_errors::{Result, StackableErr};
 use tokio::{io::AsyncWriteExt, sync::Mutex};
 
@@ -338,7 +339,7 @@ pub async fn total_teardown(
         .containers
         .map_or_else(Vec::new, |containers| containers.into_keys().collect());
 
-    let mut futs = live_containers
+    let futs = live_containers
         .into_iter()
         .chain(known_container_names)
         .map(|container_name| {
@@ -368,14 +369,11 @@ pub async fn total_teardown(
         })
         .collect::<Vec<_>>();
 
-    let mut errs = vec![];
-    while !futs.is_empty() {
-        let (res, _, rest) = futures::future::select_all(futs).await;
-        if let Err(err) = res {
-            errs.push(err)
-        };
-        futs = rest;
-    }
+    let mut errs = join_all(futs)
+        .await
+        .into_iter()
+        .filter_map(|res| if let Err(err) = res { Some(err) } else { None })
+        .collect::<Vec<_>>();
 
     if let Err(err) = docker.remove_network(network_name).await.stack() {
         errs.push(err)

--- a/super_orchestrator/src/api_docker/super_docker_file.rs
+++ b/super_orchestrator/src/api_docker/super_docker_file.rs
@@ -4,7 +4,7 @@ use std::{
     sync::Arc,
 };
 
-use futures::TryStreamExt;
+use futures::{future::try_join_all, TryStreamExt};
 use stacked_errors::{Result, StackableErr};
 
 use crate::{
@@ -195,7 +195,7 @@ impl SuperDockerfile {
         }
 
         let this = Arc::new(std::sync::Mutex::new(self));
-        let mut futs = v
+        let futs = v
             .into_iter()
             .map(|(from, to)| {
                 let this = this.clone();
@@ -214,11 +214,7 @@ impl SuperDockerfile {
             })
             .collect::<Vec<_>>();
 
-        while !futs.is_empty() {
-            let (res, _, rest) = futures::future::select_all(futs).await;
-            res.stack()?.stack()?;
-            futs = rest;
-        }
+        try_join_all(futs).await.stack()?;
 
         self = Arc::try_unwrap(this).unwrap().into_inner().stack()?;
 
@@ -243,7 +239,7 @@ impl SuperDockerfile {
         }
 
         let this = Arc::new(std::sync::Mutex::new(self));
-        let mut futs = v
+        let futs = v
             .into_iter()
             .map(|(to, mode, content)| {
                 let this = this.clone();
@@ -263,11 +259,7 @@ impl SuperDockerfile {
             })
             .collect::<Vec<_>>();
 
-        while !futs.is_empty() {
-            let (res, _, rest) = futures::future::select_all(futs).await;
-            res.stack()??;
-            futs = rest;
-        }
+        try_join_all(futs).await.stack()?;
 
         self = Arc::try_unwrap(this).unwrap().into_inner().stack()?;
 
@@ -371,12 +363,15 @@ impl SuperDockerfile {
         }
 
         let mut cur_binary_path = std::env::current_exe().stack()?;
-        let cur_binary_name = cur_binary_path
-            .file_name()
-            .unwrap()
-            .to_str()
-            .stack()?
-            .to_string();
+
+        let cur_binary_name = normalize_windows_exe_path_for_cargo_binary(
+            cur_binary_path
+                .file_name()
+                .unwrap()
+                .to_str()
+                .stack()?
+                .to_string(),
+        );
         cur_binary_path.pop();
 
         let mut is_musl = true;
@@ -391,7 +386,7 @@ impl SuperDockerfile {
             cur_binary_path.pop();
         }
 
-        let bootstrap_path = normalize_windows_exe_path_for_cargo_binary(to.to_string());
+        let bootstrap_path = to;
 
         if !is_musl {
             tracing::debug!("Current binary is not linked with musl, building to accordingly");
@@ -529,9 +524,14 @@ impl SuperDockerfile {
     }
 }
 
+/// When dealing with windows binaries, the file will have the .exe extension
+/// while the rust binary won't. If we don't remove the .exe, the command will
+/// be like `cargo build --bin ${bin_name}.exe
 fn normalize_windows_exe_path_for_cargo_binary(path: String) -> String {
     if cfg!(target_os = "windows") {
-        path.strip_suffix(".exe").map(str::to_string).unwrap_or(path)
+        path.strip_suffix(".exe")
+            .map(str::to_string)
+            .unwrap_or(path)
     } else {
         path
     }


### PR DESCRIPTION
When designing the new super_orchestrator architecture, I decided that everything about running containers would be very opinionated because we don't need as many features for testing (which is the purpose of the ContainerNetwork struct).

I was wrong about parts of my opinion, I just hit a case where I need to set an ip address manually. This PR adds that capability when creating a container for a specific network.