### PR TITLE
fix: static ip and port binding

### DIFF
--- a/super_orchestrator/src/api_docker/container_network.rs
+++ b/super_orchestrator/src/api_docker/container_network.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    net::IpAddr,
+    net::{Ipv4Addr, Ipv6Addr},
     path::PathBuf,
     str::FromStr,
     time::{Duration, Instant},
@@ -89,7 +89,10 @@ pub struct ExtraAddContainerOptions {
     pub mac_address: Option<String>,
     /// Caution, when setting ip addr manually, make sure your gateway can't
     /// assign other containers to the same address.
-    pub ip_addr: Option<IpAddr>,
+    pub ipv4_addr: Option<Ipv4Addr>,
+    /// Caution, when setting ip addr manually, make sure your gateway can't
+    /// assign other containers to the same address.
+    pub ipv6_addr: Option<Ipv6Addr>,
 }
 
 // TODO make the rest of `super_orchestrator` use tokio::signal::ctrl_c instead,
@@ -697,7 +700,10 @@ impl ContainerNetwork {
             .stack()?
             .into_iter()
             .any(|healthy| !healthy)
-        {}
+        {
+            tracing::debug!("Waiting for containers to be healthy...");
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
 
         Ok(())
     }

--- a/super_orchestrator/src/api_docker/container_runner.rs
+++ b/super_orchestrator/src/api_docker/container_runner.rs
@@ -7,7 +7,7 @@ use std::{
 
 // reexport from bollard
 pub use bollard::secret::DeviceMapping;
-use bollard::secret::EndpointSettings;
+use bollard::secret::{EndpointIpamConfig, EndpointSettings};
 use futures::future::join_all;
 use stacked_errors::{Result, StackableErr};
 use tokio::{io::AsyncWriteExt, sync::Mutex};
@@ -162,16 +162,22 @@ impl ContainerRunner {
                     open_stdin: Some(true),
                     // setup network
                     networking_config: Some(bollard::container::NetworkingConfig {
-                        endpoints_config: [(
-                            network_name,
-                            self.network_opts
-                                .ip_addr
-                                .map(|ip_addr| EndpointSettings {
-                                    ip_address: Some(ip_addr.to_string()),
-                                    ..Default::default()
-                                })
-                                .unwrap_or_default(),
-                        )]
+                        endpoints_config: [(network_name, EndpointSettings {
+                            ipam_config: Some(EndpointIpamConfig {
+                                ipv4_address: self
+                                    .network_opts
+                                    .ipv4_addr
+                                    .as_ref()
+                                    .map(ToString::to_string),
+                                ipv6_address: self
+                                    .network_opts
+                                    .ipv6_addr
+                                    .as_ref()
+                                    .map(ToString::to_string),
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        })]
                         .into_iter()
                         .collect(),
                     }),


### PR DESCRIPTION
Allow users to set port binding protocol (it's tcp by default)

Fix last implementation of setting static ip, was using the wrong field (there's like 9 ip_address fields smh)

Added a 1 second timeout when health checking