### PR TITLE
fix: allow multiple bindings to same container port/proto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.17.0] - 2025-06-02
+### Fixes
+- Allow multiple bindings to same container in API docker
+
 ## [0.17.0] - 2025-05-28
 ### Crate
 - Updated to `nix` 0.30

--- a/super_orchestrator/Cargo.toml
+++ b/super_orchestrator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "super_orchestrator"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 authors = ["Aaron Kutch <aaronkutch@att.net>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Current implementation can only have 1 port/proto per binding

So we can't, for example, bind ipv6 and ipv4 to same domain. With this change we can

![multiple_bindings](https://github.com/user-attachments/assets/acd76dfd-e697-4ea6-b2d5-ae9ae7acf11a)
